### PR TITLE
fix #218 重试逻辑Bad Request报错

### DIFF
--- a/code/services/openai/common.go
+++ b/code/services/openai/common.go
@@ -120,6 +120,10 @@ func (gpt *ChatGPT) doAPIRequestWithRetry(url, method string,
 	var response *http.Response
 	var retry int
 	for retry = 0; retry <= maxRetries; retry++ {
+		// set body
+		if retry > 0 {
+			req.Body = ioutil.NopCloser(bytes.NewReader(requestBodyData))
+		}
 		response, err = client.Do(req)
 		//fmt.Println("--------------------")
 		//fmt.Println("req", req.Header)


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[fix]、[documentation]、[dependencies]、[test] 。以便于Actions自动生成Releases时自动对PR进行归类。-->
## 描述
在进行重试逻辑时，重置req的Body，修复在重试时，直接返回Bad Request的bug

```go
	for retry = 0; retry <= maxRetries; retry++ {
		// set body
		if retry > 0 {
			req.Body = ioutil.NopCloser(bytes.NewReader(requestBodyData))
		}
		response, err = client.Do(req)
		//fmt.Println("--------------------")
		//fmt.Println("req", req.Header)
		//fmt.Printf("response: %v", response)
		// read body
		if err != nil || response.StatusCode < 200 || response.StatusCode >= 300 {

			body, _ := ioutil.ReadAll(response.Body)
			fmt.Println("body", string(body))

			gpt.Lb.SetAvailability(api.Key, false)
			if retry == maxRetries {
				break
			}
			time.Sleep(time.Duration(retry+1) * time.Second)
		} else {
			break
		}
	}
```

## 相关问题
- [#218]
