### PR TITLE
fix: change cAPort to caPort

### DIFF
--- a/s.yaml
+++ b/s.yaml
@@ -28,7 +28,7 @@ services:
         name: "feishu-chatgpt"
         description: 'a simple feishubot by serverless devs'
         codeUri: './code'
-        cAPort: 9000
+        caPort: 9000
         customRuntimeConfig:
           command:
             - ./target/main


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[fix]、[documentation]、[dependencies]、[test] 。以便于Actions自动生成Releases时自动对PR进行归类。-->
## 描述

默认 9000 端口，想要自定义端口，发现 s.yaml 描述文件有点错误。



