### PR TITLE
修改判断新话题的msg数量为3

### DIFF
--- a/code/handlers/event_msg_action.go
+++ b/code/handlers/event_msg_action.go
@@ -39,7 +39,7 @@ func (*MessageAction) Execute(a *ActionInfo) bool {
 	msg = append(msg, completions)
 	a.handler.sessionCache.SetMsg(*a.info.sessionId, msg)
 	//if new topic
-	if len(msg) == 4 {
+	if len(msg) == 3 {
 		//fmt.Println("new topic", msg[1].Content)
 		sendNewTopicCard(*a.ctx, a.info.sessionId, a.info.msgId,
 			completions.Content)

--- a/code/handlers/event_msg_action.go
+++ b/code/handlers/event_msg_action.go
@@ -39,7 +39,7 @@ func (*MessageAction) Execute(a *ActionInfo) bool {
 	msg = append(msg, completions)
 	a.handler.sessionCache.SetMsg(*a.info.sessionId, msg)
 	//if new topic
-	if len(msg) == 2 {
+	if len(msg) == 4 {
 		//fmt.Println("new topic", msg[1].Content)
 		sendNewTopicCard(*a.ctx, a.info.sessionId, a.info.msgId,
 			completions.Content)


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[fix]、[documentation]、[dependencies]、[test] 。以便于Actions自动生成Releases时自动对PR进行归类。-->
## 描述
更正新话题判断逻辑

## 相关问题
- 新话题未按卡片显示

## 原因

开启一个新话题的时，一个sys+一个user+一个assistant1 ， 合计数量为 3