### PR TITLE
[feature] Support markdown of code block

### DIFF
--- a/code/handlers/msg.go
+++ b/code/handlers/msg.go
@@ -161,14 +161,8 @@ func withMainMd(msg string) larkcard.MessageCardElement {
 	if i != nil {
 		return nil
 	}
-	mainElement := larkcard.NewMessageCardDiv().
-		Fields([]*larkcard.MessageCardField{larkcard.NewMessageCardField().
-			Text(larkcard.NewMessageCardLarkMd().
-				Content(msg).
-				Build()).
-			IsShort(true).
-			Build()}).
-		Build()
+	mainElement := larkcard.NewMessageCardMarkdown().
+		Content(msg).Build()
 	return mainElement
 }
 
@@ -753,7 +747,7 @@ func sendNewTopicCard(ctx context.Context,
 	sessionId *string, msgId *string, content string) {
 	newCard, _ := newSendCard(
 		withHeader("👻️ 已开启新的话题", larkcard.TemplateBlue),
-		withMainText(content),
+		withMainMd(content),
 		withNote("提醒：点击对话框参与回复，可保持话题连贯"))
 	replyCard(ctx, msgId, newCard)
 }
@@ -762,7 +756,7 @@ func sendOldTopicCard(ctx context.Context,
 	sessionId *string, msgId *string, content string) {
 	newCard, _ := newSendCard(
 		withHeader("🔃️ 上下文的话题", larkcard.TemplateBlue),
-		withMainText(content),
+		withMainMd(content),
 		withNote("提醒：点击对话框参与回复，可保持话题连贯"))
 	replyCard(ctx, msgId, newCard)
 }
@@ -771,7 +765,7 @@ func sendVisionTopicCard(ctx context.Context,
 	sessionId *string, msgId *string, content string) {
 	newCard, _ := newSendCard(
 		withHeader("🕵️图片推理结果", larkcard.TemplateBlue),
-		withMainText(content),
+		withMainMd(content),
 		withNote("让LLM和你一起推理图片的内容~"))
 	replyCard(ctx, msgId, newCard)
 }


### PR DESCRIPTION
support markdown of code block

<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[fix]、[documentation]、[dependencies]、[test] 。以便于Actions自动生成Releases时自动对PR进行归类。-->
## 描述
修改了非流式输出下的文本格式，替换使用NewMessageCardMarkdown类，使得客户端对markdown中代码块实现支持。

![image](https://github.com/ConnectAI-E/feishu-openai/assets/34151816/b36a93da-b3b4-4769-ba2b-dd60a70a74e3)

## 相关问题
- [274]（[问题链接](https://github.com/ConnectAI-E/feishu-openai/issues/274)）
